### PR TITLE
chore: skip the test report when owner is not linuxsuren

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
         run: |
           go test ./... -coverprofile coverage.out
       - name: Report
+        if: github.repository_owner == 'linuxsuren'
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |


### PR DESCRIPTION
See also https://github.com/LinuxSuRen/api-testing/pull/60#pullrequestreview-1414391415