### PR TITLE
feat: support running before and after jobs with API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 
 This is a API testing tool.
 
-## Feature
+## Features
 
 *   Response Body fields equation check
 *   Response Body [eval](https://expr.medv.io/)
 *   Verify the Kubernetes resources
 *   Validate the response body with [JSON schema](https://json-schema.org/)
+*   Pre and post handle with the API request
 *   Output reference between TestCase
 *   Run in server mode, and provide the gRPC endpoint
 *   [VS Code extension](https://github.com/LinuxSuRen/vscode-api-testing) support
@@ -71,6 +72,7 @@ You could use all the common functions which comes from [sprig](http://mastermin
 | Name | Usage |
 |---|---|
 | `randomKubernetesName` | `{{randomKubernetesName}}` to generate Kubernetes resource name randomly, the name will have 8  chars |
+| `sleep` | `{{sleep(1)}}` in the pre and post request handle |
 
 ## Verify against Kubernetes
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,40 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	atesting "github.com/linuxsuren/api-testing/pkg/testing"
 	exec "github.com/linuxsuren/go-fake-runtime"
 )
-
-func TestSetRelativeDir(t *testing.T) {
-	type args struct {
-		configFile string
-		testcase   *atesting.TestCase
-	}
-	tests := []struct {
-		name   string
-		args   args
-		verify func(*testing.T, *atesting.TestCase)
-	}{{
-		name: "normal",
-		args: args{
-			configFile: "a/b/c.yaml",
-			testcase: &atesting.TestCase{
-				Prepare: atesting.Prepare{
-					Kubernetes: []string{"deploy.yaml"},
-				},
-			},
-		},
-		verify: func(t *testing.T, testCase *atesting.TestCase) {
-			assert.Equal(t, "a/b/deploy.yaml", testCase.Prepare.Kubernetes[0])
-		},
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setRelativeDir(tt.args.configFile, tt.args.testcase)
-			tt.verify(t, tt.args.testcase)
-		})
-	}
-}
 
 func TestCreateRunCommand(t *testing.T) {
 	cmd := createRunCommand()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -216,7 +215,6 @@ func (o *runOption) runSuite(suite string, dataContext map[string]interface{}, c
 		case <-stopSingal:
 			return
 		default:
-			setRelativeDir(suite, &testCase)
 			o.limiter.Accept()
 
 			ctxWithTimeout, _ := context.WithTimeout(ctx, o.requestTimeout)
@@ -237,12 +235,4 @@ func (o *runOption) runSuite(suite string, dataContext map[string]interface{}, c
 
 func getDefaultContext() map[string]interface{} {
 	return map[string]interface{}{}
-}
-
-func setRelativeDir(configFile string, testcase *testing.TestCase) {
-	dir := filepath.Dir(configFile)
-
-	for i := range testcase.Prepare.Kubernetes {
-		testcase.Prepare.Kubernetes[i] = path.Join(dir, testcase.Prepare.Kubernetes[i])
-	}
 }

--- a/pkg/runner/expr_function.go
+++ b/pkg/runner/expr_function.go
@@ -1,0 +1,26 @@
+// Package runner provides the common expr style functions
+package runner
+
+import (
+	"fmt"
+	"time"
+)
+
+// ExprFuncSleep is a expr function for sleeping
+func ExprFuncSleep(params ...interface{}) (res interface{}, err error) {
+	if len(params) < 1 {
+		err = fmt.Errorf("the duration param is required")
+		return
+	}
+
+	switch duration := params[0].(type) {
+	case int:
+		time.Sleep(time.Duration(duration) * time.Second)
+	case string:
+		var dur time.Duration
+		if dur, err = time.ParseDuration(duration); err == nil {
+			time.Sleep(dur)
+		}
+	}
+	return
+}

--- a/pkg/runner/expr_function_test.go
+++ b/pkg/runner/expr_function_test.go
@@ -1,0 +1,33 @@
+package runner_test
+
+import (
+	"testing"
+
+	"github.com/linuxsuren/api-testing/pkg/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExprFuncSleep(t *testing.T) {
+	tests := []struct {
+		name   string
+		params []interface{}
+		hasErr bool
+	}{{
+		name:   "string format duration",
+		params: []interface{}{"0.01s"},
+		hasErr: false,
+	}, {
+		name:   "without params",
+		hasErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := runner.ExprFuncSleep(tt.params...)
+			if tt.hasErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/runner/simple_test.go
+++ b/pkg/runner/simple_test.go
@@ -43,8 +43,8 @@ func TestTestCase(t *testing.T) {
 	}{{
 		name: "failed during the prepare stage",
 		testCase: &atest.TestCase{
-			Prepare: atest.Prepare{
-				Kubernetes: []string{"demo.yaml"},
+			Before: atest.Job{
+				Items: []string{"demo.yaml"},
 			},
 		},
 		execer: fakeruntime.FakeExecer{ExpectError: errors.New("fake")},
@@ -69,8 +69,8 @@ func TestTestCase(t *testing.T) {
 					`data.name == "linuxsuren"`,
 				},
 			},
-			Prepare: atest.Prepare{
-				Kubernetes: []string{"demo.yaml"},
+			Before: atest.Job{
+				Items: []string{"sleep(1)"},
 			},
 			Clean: atest.Clean{
 				CleanPrepare: true,
@@ -406,6 +406,32 @@ func TestJSONSchemaValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := jsonSchemaValidation(tt.schema, []byte(tt.body))
+			assert.Equal(t, tt.hasErr, err != nil, err)
+		})
+	}
+}
+
+func TestRunJob(t *testing.T) {
+	tests := []struct {
+		name   string
+		job    atest.Job
+		hasErr bool
+	}{{
+		name: "sleep 1s",
+		job: atest.Job{
+			Items: []string{"sleep(1)"},
+		},
+		hasErr: false,
+	}, {
+		name: "no params",
+		job: atest.Job{
+			Items: []string{"sleep()"},
+		},
+		hasErr: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runJob(tt.job)
 			assert.Equal(t, tt.hasErr, err != nil, err)
 		})
 	}

--- a/pkg/testing/case.go
+++ b/pkg/testing/case.go
@@ -11,7 +11,8 @@ type TestSuite struct {
 type TestCase struct {
 	Name    string `yaml:"name" json:"name"`
 	Group   string
-	Prepare Prepare  `yaml:"prepare" json:"-"`
+	Before  Job      `yaml:"before" json:"before"`
+	After   Job      `yaml:"after" json:"after"`
 	Request Request  `yaml:"request" json:"request"`
 	Expect  Response `yaml:"expect" json:"expect"`
 	Clean   Clean    `yaml:"clean" json:"-"`
@@ -31,9 +32,9 @@ func (c *TestCase) InScope(items []string) bool {
 	return false
 }
 
-// Prepare does the prepare work
-type Prepare struct {
-	Kubernetes []string `yaml:"kubernetes"`
+// Job contains a list of jobs
+type Job struct {
+	Items []string `yaml:"items"`
 }
 
 // Request represents a HTTP request

--- a/pkg/testing/parser_test.go
+++ b/pkg/testing/parser_test.go
@@ -28,6 +28,12 @@ func TestParse(t *testing.T) {
 }
 `,
 			},
+			Before: Job{
+				Items: []string{"sleep(1)"},
+			},
+			After: Job{
+				Items: []string{"sleep(1)"},
+			},
 		}, suite.Items[0])
 	}
 

--- a/sample/api-testing-schema.json
+++ b/sample/api-testing-schema.json
@@ -37,6 +37,12 @@
                 },
                 "expect": {
                     "$ref": "#/definitions/Expect"
+                },
+                "before": {
+                    "$ref": "#/definitions/Job"
+                },
+                "after": {
+                    "$ref": "#/definitions/Job"
                 }
             },
             "required": [
@@ -121,6 +127,22 @@
                 "api"
             ],
             "title": "Request"
+        },
+        "Job": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "items"
+            ],
+            "title": "Job"
         }
     }
 }

--- a/sample/testsuite-gitee.yaml
+++ b/sample/testsuite-gitee.yaml
@@ -4,6 +4,9 @@ name: Gitee
 api: https://gitee.com/api/v5
 items:
 - name: stargazers
+  before:
+    items:
+    - sleep(1)
   request:
     api: /repos/linuxsuren/api-testing/stargazers
   expect:

--- a/sample/testsuite-gitlab.yaml
+++ b/sample/testsuite-gitlab.yaml
@@ -12,6 +12,12 @@ items:
       {
         "type": "array"
       }
+  before:
+    items:
+      - "sleep(1)"
+  after:
+    items:
+      - "sleep(1)"
 - name: project
   request:
     api: https://gitlab.com/api/v4/projects/{{int64 (index .projects 0).id}}


### PR DESCRIPTION
fix https://github.com/LinuxSuRen/api-testing/issues/68

sample usage:
```
  after:
    items:
      - "sleep(1)"
```