### PR TITLE
feat: support to calculate the API coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ Usage:
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
+  func        Print all the supported functions
   help        Help about any command
   json        Print the JSON schema of the test suites struct
   run         Run the test suite
   sample      Generate a sample test case YAML file
   server      Run as a server mode
+  service     Install atest as a Linux service
 
 Flags:
   -h, --help      help for atest

--- a/cmd/function.go
+++ b/cmd/function.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"go/ast"
 	"go/doc"
 	"go/parser"
@@ -26,7 +25,7 @@ func createFunctionCmd() (c *cobra.Command) {
 					cmd.Println(reflect.TypeOf(fn))
 					desc := FuncDescription(fn)
 					if desc != "" {
-						fmt.Println(desc)
+						cmd.Println(desc)
 					}
 				} else {
 					cmd.Println("No such function")

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -116,6 +116,14 @@ func TestRunCommand(t *testing.T) {
 		args:    []string{"-p", simpleSuite, "--report", "md", "--report-file", tmpFile.Name()},
 		hasErr:  false,
 	}, {
+		name: "report with swagger URL",
+		prepare: func() {
+			fooPrepare()
+			fooPrepare()
+		},
+		args:   []string{"-p", simpleSuite, "--swagger-url", urlFoo + "/bar"},
+		hasErr: false,
+	}, {
 		name:    "report file with error",
 		prepare: fooPrepare,
 		args:    []string{"-p", simpleSuite, "--report", "md", "--report-file", path.Join(tmpFile.Name(), "fake")},
@@ -124,9 +132,10 @@ func TestRunCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer gock.Clean()
+			buf := new(bytes.Buffer)
 			util.MakeSureNotNil(tt.prepare)()
 			root := &cobra.Command{Use: "root"}
-			root.SetOut(&bytes.Buffer{})
+			root.SetOut(buf)
 			root.AddCommand(createRunCommand())
 
 			root.SetArgs(append([]string{"run"}, tt.args...))
@@ -179,6 +188,15 @@ func TestPreRunE(t *testing.T) {
 		name: "std report",
 		opt: &runOption{
 			report: "std",
+		},
+		verify: func(t *testing.T, ro *runOption, err error) {
+			assert.Nil(t, err)
+			assert.NotNil(t, ro.reportWriter)
+		},
+	}, {
+		name: "html report",
+		opt: &runOption{
+			report: "html",
 		},
 		verify: func(t *testing.T, ro *runOption, err error) {
 			assert.Nil(t, err)

--- a/pkg/apispec/swagger.go
+++ b/pkg/apispec/swagger.go
@@ -1,0 +1,98 @@
+package apispec
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type Swagger struct {
+	Swagger string                           `json:"swagger"`
+	Paths   map[string]map[string]SwaggerAPI `json:"paths"`
+	Info    SwaggerInfo                      `json:"info"`
+}
+
+type SwaggerAPI struct {
+	OperationId string `json:"operationId"`
+	Summary     string `json:"summary"`
+}
+
+type SwaggerInfo struct {
+	Description string `json:"description"`
+	Title       string `json:"title"`
+	Version     string `json:"version"`
+}
+
+type APIConverage interface {
+	HaveAPI(path, method string) (exist bool)
+	APICount() (count int)
+}
+
+// HaveAPI check if the swagger has the API.
+// If the path is /api/v1/names/linuxsuren, then will match /api/v1/names/{name}
+func (s *Swagger) HaveAPI(path, method string) (exist bool) {
+	method = strings.ToLower(method)
+	for item := range s.Paths {
+		if matchAPI(path, item) {
+			for m := range s.Paths[item] {
+				if strings.ToLower(m) == method {
+					exist = true
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+func matchAPI(particularAPI, swaggerAPI string) (matched bool) {
+	result := swaggerAPIConvert(swaggerAPI)
+	reg, err := regexp.Compile(result)
+	if err == nil {
+		matched = reg.MatchString(particularAPI)
+	}
+	return
+}
+
+func swaggerAPIConvert(text string) (result string) {
+	result = text
+	reg, err := regexp.Compile("{.*}")
+	if err == nil {
+		result = reg.ReplaceAllString(text, ".*")
+	}
+	return
+}
+
+// APICount return the count of APIs
+func (s *Swagger) APICount() (count int) {
+	for path := range s.Paths {
+		for range s.Paths[path] {
+			count++
+		}
+	}
+	return
+}
+
+func ParseToSwagger(data []byte) (swagger *Swagger, err error) {
+	swagger = &Swagger{}
+	err = json.Unmarshal(data, swagger)
+	return
+}
+
+func ParseURLToSwagger(swaggerURL string) (swagger *Swagger, err error) {
+	var resp *http.Response
+	if resp, err = http.Get(swaggerURL); err == nil && resp != nil && resp.StatusCode == http.StatusOK {
+		swagger, err = ParseStreamToSwagger(resp.Body)
+	}
+	return
+}
+
+func ParseStreamToSwagger(stream io.Reader) (swagger *Swagger, err error) {
+	var data []byte
+	if data, err = io.ReadAll(stream); err == nil {
+		swagger, err = ParseToSwagger(data)
+	}
+	return
+}

--- a/pkg/apispec/swagger_test.go
+++ b/pkg/apispec/swagger_test.go
@@ -1,0 +1,111 @@
+package apispec_test
+
+import (
+	"net/http"
+	"testing"
+
+	_ "embed"
+
+	"github.com/h2non/gock"
+	"github.com/linuxsuren/api-testing/pkg/apispec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseURLToSwagger(t *testing.T) {
+	tests := []struct {
+		name       string
+		swaggerURL string
+		verify     func(t *testing.T, swagger *apispec.Swagger, err error)
+	}{{
+		name:       "normal",
+		swaggerURL: "http://foo",
+		verify: func(t *testing.T, swagger *apispec.Swagger, err error) {
+			assert.NoError(t, err)
+			assert.Equal(t, "2.0", swagger.Swagger)
+			assert.Equal(t, apispec.SwaggerInfo{
+				Description: "sample",
+				Title:       "sample",
+				Version:     "1.0.0",
+			}, swagger.Info)
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gock.New(tt.swaggerURL).Get("/").Reply(200).BodyString(testdataSwaggerJSON)
+			defer gock.Off()
+
+			s, err := apispec.ParseURLToSwagger(tt.swaggerURL)
+			tt.verify(t, s, err)
+		})
+	}
+}
+
+func TestHaveAPI(t *testing.T) {
+	tests := []struct {
+		name         string
+		swaggerURL   string
+		path, method string
+		expectExist  bool
+	}{{
+		name:        "normal, exist",
+		swaggerURL:  "http://foo",
+		path:        "/api/v1/users",
+		method:      http.MethodGet,
+		expectExist: true,
+	}, {
+		name:        "create user, exist",
+		swaggerURL:  "http://foo",
+		path:        "/api/v1/users",
+		method:      http.MethodPost,
+		expectExist: true,
+	}, {
+		name:        "get a user, exist",
+		swaggerURL:  "http://foo",
+		path:        "/api/v1/users/linuxsuren",
+		method:      http.MethodGet,
+		expectExist: true,
+	}, {
+		name:        "normal, not exist",
+		swaggerURL:  "http://foo",
+		path:        "/api/v1/users",
+		method:      http.MethodDelete,
+		expectExist: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gock.New(tt.swaggerURL).Get("/").Reply(200).BodyString(testdataSwaggerJSON)
+			defer gock.Off()
+
+			swagger, err := apispec.ParseURLToSwagger(tt.swaggerURL)
+			assert.NoError(t, err)
+			exist := swagger.HaveAPI(tt.path, tt.method)
+			assert.Equal(t, tt.expectExist, exist)
+		})
+	}
+}
+
+func TestAPICount(t *testing.T) {
+	tests := []struct {
+		name        string
+		swaggerURL  string
+		expectCount int
+	}{{
+		name:        "normal",
+		swaggerURL:  "http://foo",
+		expectCount: 5,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gock.New(tt.swaggerURL).Get("/").Reply(200).BodyString(testdataSwaggerJSON)
+			defer gock.Off()
+
+			swagger, err := apispec.ParseURLToSwagger(tt.swaggerURL)
+			assert.NoError(t, err)
+			count := swagger.APICount()
+			assert.Equal(t, tt.expectCount, count)
+		})
+	}
+}
+
+//go:embed testdata/swagger.json
+var testdataSwaggerJSON string

--- a/pkg/apispec/testdata/swagger.json
+++ b/pkg/apispec/testdata/swagger.json
@@ -1,0 +1,34 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "sample",
+        "title": "sample",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/api/v1/users": {
+            "get": {
+                "summary": "summary",
+                "operationId": "getUsers"
+            },
+            "post": {
+                "summary": "summary",
+                "operationId": "createUser"
+            }
+        },
+        "/api/v1/users/{user}": {
+            "get": {
+                "summary": "summary",
+                "operationId": "getUser"
+            },
+            "delete": {
+                "summary": "summary",
+                "operationId": "deleteUser"
+            },
+            "put": {
+                "summary": "summary",
+                "operationId": "updateUser"
+            }
+        }
+    }
+}

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -14,6 +14,7 @@ import (
 	"github.com/andreyvit/diff"
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
+	"github.com/linuxsuren/api-testing/pkg/apispec"
 	"github.com/linuxsuren/api-testing/pkg/runner/kubernetes"
 	"github.com/linuxsuren/api-testing/pkg/testing"
 	fakeruntime "github.com/linuxsuren/go-fake-runtime"
@@ -153,6 +154,7 @@ func (r ReportResultSlice) Swap(i, j int) {
 // ReportResultWriter is the interface of the report writer
 type ReportResultWriter interface {
 	Output([]ReportResult) error
+	WithAPIConverage(apiConverage apispec.APIConverage) ReportResultWriter
 }
 
 // TestReporter is the interface of the report

--- a/pkg/runner/writer_html.go
+++ b/pkg/runner/writer_html.go
@@ -4,11 +4,13 @@ import (
 	_ "embed"
 	"io"
 
+	"github.com/linuxsuren/api-testing/pkg/apispec"
 	"github.com/linuxsuren/api-testing/pkg/render"
 )
 
 type htmlResultWriter struct {
-	writer io.Writer
+	writer       io.Writer
+	apiConverage apispec.APIConverage
 }
 
 // NewHTMLResultWriter creates a new htmlResultWriter
@@ -19,6 +21,12 @@ func NewHTMLResultWriter(writer io.Writer) ReportResultWriter {
 // Output writes the HTML base report to target writer
 func (w *htmlResultWriter) Output(result []ReportResult) (err error) {
 	return render.RenderThenPrint("html-report", htmlReport, result, w.writer)
+}
+
+// WithAPIConverage sets the api coverage
+func (w *htmlResultWriter) WithAPIConverage(apiConverage apispec.APIConverage) ReportResultWriter {
+	w.apiConverage = apiConverage
+	return w
 }
 
 //go:embed data/html.html

--- a/pkg/runner/writer_html_test.go
+++ b/pkg/runner/writer_html_test.go
@@ -32,6 +32,7 @@ func TestHTMLResultWriter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := runner.NewHTMLResultWriter(tt.buf)
+			w.WithAPIConverage(nil)
 			err := w.Output(tt.results)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expect, tt.buf.String())

--- a/pkg/runner/writer_markdown.go
+++ b/pkg/runner/writer_markdown.go
@@ -4,11 +4,13 @@ import (
 	_ "embed"
 	"io"
 
+	"github.com/linuxsuren/api-testing/pkg/apispec"
 	"github.com/linuxsuren/api-testing/pkg/render"
 )
 
 type markdownResultWriter struct {
-	writer io.Writer
+	writer       io.Writer
+	apiConverage apispec.APIConverage
 }
 
 // NewMarkdownResultWriter creates the Markdown writer
@@ -19,6 +21,12 @@ func NewMarkdownResultWriter(writer io.Writer) ReportResultWriter {
 // Output writes the Markdown based report to target writer
 func (w *markdownResultWriter) Output(result []ReportResult) (err error) {
 	return render.RenderThenPrint("md-report", markdownReport, result, w.writer)
+}
+
+// WithAPIConverage sets the api coverage
+func (w *markdownResultWriter) WithAPIConverage(apiConverage apispec.APIConverage) ReportResultWriter {
+	w.apiConverage = apiConverage
+	return w
 }
 
 //go:embed data/report.md

--- a/pkg/runner/writer_markdown_test.go
+++ b/pkg/runner/writer_markdown_test.go
@@ -11,6 +11,7 @@ import (
 func TestMarkdownWriter(t *testing.T) {
 	buf := new(bytes.Buffer)
 	writer := runner.NewMarkdownResultWriter(buf)
+	writer.WithAPIConverage(nil)
 
 	err := writer.Output([]runner.ReportResult{{
 		API:     "api",

--- a/pkg/runner/writer_std_test.go
+++ b/pkg/runner/writer_std_test.go
@@ -76,6 +76,7 @@ api 1ns 1ns 1ns 10 1 0
 				return
 			}
 
+			writer.WithAPIConverage(nil)
 			err := writer.Output(tt.results)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expect, tt.buf.String())

--- a/pkg/util/expand.go
+++ b/pkg/util/expand.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Expand the text with brace syntax.
+// Such as: /home/{good,bad} -> [/home/good, /home/bad]
+func Expand(text string) (result []string) {
+	reg := regexp.MustCompile(`\{.*\}`)
+	if reg.MatchString(text) {
+		brace := reg.FindString(text)
+		braceItem := strings.TrimPrefix(brace, "{")
+		braceItem = strings.TrimSuffix(braceItem, "}")
+		items := strings.Split(braceItem, ",")
+
+		for _, item := range items {
+			result = append(result, strings.ReplaceAll(text, brace, item))
+		}
+	} else {
+		result = []string{text}
+	}
+	return
+}

--- a/pkg/util/expand_test.go
+++ b/pkg/util/expand_test.go
@@ -1,0 +1,34 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/linuxsuren/api-testing/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []string
+	}{{
+		name:   "without brace",
+		input:  "/home",
+		expect: []string{"/home"},
+	}, {
+		name:   "with brace",
+		input:  "/home/{good,bad}",
+		expect: []string{"/home/good", "/home/bad"},
+	}, {
+		name:   "with brace, have suffix",
+		input:  "/home/{good,bad}.yaml",
+		expect: []string{"/home/good.yaml", "/home/bad.yaml"},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := util.Expand(tt.input)
+			assert.Equal(t, tt.expect, got, got)
+		})
+	}
+}


### PR DESCRIPTION
There are two important features in this PR. Now it could support brace expansion, and calculate the API coverage via Swagger:

```shell
atest run -p 'docs/api-testing/test-suite-{vm,resource}.yaml' --swagger-url http://172.11.0.13:32535/apidocs.json
```