### PR TITLE
feat: add some css to the HTML format report

### DIFF
--- a/pkg/runner/data/html.html
+++ b/pkg/runner/data/html.html
@@ -45,7 +45,6 @@
     tr:hover {
       background-color: #f9f9f9;
     }
-
     </style>
 </head>
 <body>

--- a/pkg/runner/data/html.html
+++ b/pkg/runner/data/html.html
@@ -16,6 +16,36 @@
     width: 100%;
     height: 60px;
     }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    
+    caption {
+      font-size: 1.2em;
+      font-weight: bold;
+      padding: 8px;
+      background-color: #46723d48;
+    }
+    
+    th, td {
+      padding: 8px;
+      text-align: left;
+      border-bottom: 1px solid #ddd;
+    }
+    
+    th {
+      background-color: #f9f9f9;
+    }
+    
+    tr:nth-child(even) {
+      background-color: #f5f5f5;
+    }
+    
+    tr:hover {
+      background-color: #f9f9f9;
+    }
+
     </style>
 </head>
 <body>

--- a/pkg/runner/testdata/report.html
+++ b/pkg/runner/testdata/report.html
@@ -45,7 +45,6 @@
     tr:hover {
       background-color: #f9f9f9;
     }
-    
     </style>
 </head>
 <body>

--- a/pkg/runner/testdata/report.html
+++ b/pkg/runner/testdata/report.html
@@ -16,6 +16,36 @@
     width: 100%;
     height: 60px;
     }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    
+    caption {
+      font-size: 1.2em;
+      font-weight: bold;
+      padding: 8px;
+      background-color: #46723d48;
+    }
+    
+    th, td {
+      padding: 8px;
+      text-align: left;
+      border-bottom: 1px solid #ddd;
+    }
+    
+    th {
+      background-color: #f9f9f9;
+    }
+    
+    tr:nth-child(even) {
+      background-color: #f5f5f5;
+    }
+    
+    tr:hover {
+      background-color: #f9f9f9;
+    }
+    
     </style>
 </head>
 <body>


### PR DESCRIPTION
Add some css to html.html, look like this:

![image](https://github.com/LinuxSuRen/api-testing/assets/39830125/c9cb3c15-6882-4d1d-924e-f5e00d08f89a)
