### PR TITLE
chore: put the api-testing extension into the gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,3 +10,4 @@ ports:
 vscode:
   extensions:
     - golang.goteractive port
+    - linuxsuren.api-testing


### PR DESCRIPTION
See 
![image](https://github.com/LinuxSuRen/api-testing/assets/1450685/6beb6f05-51dd-4a62-b4ce-7e218d420469)
