### PR TITLE
feat: add the cookie setting for golang code generator

### DIFF
--- a/pkg/generator/data/main.go.tpl
+++ b/pkg/generator/data/main.go.tpl
@@ -16,10 +16,19 @@ func main() {
 	body := bytes.NewBufferString("{{.Request.Body.String}}")
 	{{- end }}
 
-	req, err := http.NewRequest("{{.Request.Method}}," "{{.Request.API}}", body)
+	req, err := http.NewRequest("{{.Request.Method}}", "{{.Request.API}}", body)
 	if err != nil {
 		panic(err)
 	}
+
+	{{- if gt (len .Request.Cookie) 0 }}
+	{{- range $key, $val := .Request.Cookie}}
+	req.AddCookie(&http.Cookie{
+		Name:  "{{$key}}",
+		Value: "{{$val}}",
+	})
+	{{- end}}
+	{{- end}}
 
 	{{- range $key, $val := .Request.Header}}
 	req.Header.Set("{{$key}}", "{{$val}}")


### PR DESCRIPTION
- Solved this issue: #360 .

- And there is a bug in the same file `main.ho.tpl`,  on line 19, The comma used to separate parameters was placed outside of the quotation marks. Since they are in one file, I don't think it's necessary to create a separate pull request just for this bug.

