### PR TITLE
chore: add license header in the Go code generator

### DIFF
--- a/pkg/generator/data/main.go.tpl
+++ b/pkg/generator/data/main.go.tpl
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 API Testing Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (

--- a/pkg/generator/testdata/expected_go_code.txt
+++ b/pkg/generator/testdata/expected_go_code.txt
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 API Testing Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (

--- a/pkg/generator/testdata/expected_go_cookie_request_code.txt
+++ b/pkg/generator/testdata/expected_go_cookie_request_code.txt
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 API Testing Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (

--- a/pkg/generator/testdata/expected_go_form_request_code.txt
+++ b/pkg/generator/testdata/expected_go_form_request_code.txt
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 API Testing Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (


### PR DESCRIPTION
add license header #384