### PR TITLE
feat: support combine mock and core server together

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -57,6 +57,18 @@ func TestPrintProto(t *testing.T) {
 		verify: func(t *testing.T, buf *bytes.Buffer, err error) {
 			assert.Nil(t, err)
 		},
+	}, {
+		name: "mock server, not found config",
+		args: []string{"server", "--mock-config=fake", "-p=0", "--http-port=0"},
+		verify: func(t *testing.T, buffer *bytes.Buffer, err error) {
+			assert.Error(t, err)
+		},
+	}, {
+		name: "mock server, normal",
+		args: []string{"server", "--mock-config=testdata/invalid-api.yaml", "-p=0", "--http-port=0"},
+		verify: func(t *testing.T, buffer *bytes.Buffer, err error) {
+			assert.NoError(t, err)
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,6 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0
-	github.com/gorilla/mux v1.8.1
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/h2non/gock v1.2.0
 	github.com/invopop/jsonschema v0.7.0
 	github.com/jhump/protoreflect v1.15.3
@@ -48,8 +46,6 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.2 // indirect

--- a/pkg/mock/in_memory_test.go
+++ b/pkg/mock/in_memory_test.go
@@ -33,7 +33,7 @@ func TestInMemoryServer(t *testing.T) {
 		server.Stop()
 	}()
 
-	api := "http://localhost:" + server.GetPort()
+	api := "http://localhost:" + server.GetPort() + "/mock"
 
 	_, err = http.Post(api+"/team", "", bytes.NewBufferString(`{
 		"name": "test",

--- a/pkg/mock/server.go
+++ b/pkg/mock/server.go
@@ -15,8 +15,11 @@ limitations under the License.
 */
 package mock
 
+import "net/http"
+
 type DynamicServer interface {
 	Start(reader Reader) error
+	SetupHandler(reader Reader) (http.Handler, error)
 	Stop() error
 	GetPort() string
 }

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -1,9 +1,25 @@
+/*
+Copyright 2024 API Testing Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package server
 
 import (
 	context "context"
 	"net"
 	"net/http"
+	"strings"
 )
 
 // HTTPServer is an interface for serving HTTP requests
@@ -11,6 +27,11 @@ type HTTPServer interface {
 	Serve(lis net.Listener) error
 	WithHandler(handler http.Handler)
 	Shutdown(ctx context.Context) error
+}
+
+type CombineHandler interface {
+	PutHandler(string, http.Handler)
+	GetHandler() http.Handler
 }
 
 type defaultHTTPServer struct {
@@ -35,6 +56,42 @@ func (s *defaultHTTPServer) WithHandler(h http.Handler) {
 
 func (s *defaultHTTPServer) Shutdown(ctx context.Context) error {
 	return s.server.Shutdown(ctx)
+}
+
+type defaultCombineHandler struct {
+	handlerMapping map[string]http.Handler
+	defaultHandler http.Handler
+}
+
+func NewDefaultCombineHandler() CombineHandler {
+	return &defaultCombineHandler{
+		handlerMapping: make(map[string]http.Handler),
+	}
+}
+
+func (s *defaultCombineHandler) PutHandler(name string, handler http.Handler) {
+	if name == "" {
+		s.defaultHandler = handler
+	} else {
+		s.handlerMapping[name] = handler
+	}
+}
+
+func (s *defaultCombineHandler) GetHandler() http.Handler {
+	if len(s.handlerMapping) == 0 {
+		return s.defaultHandler
+	}
+	return s
+}
+
+func (s *defaultCombineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for prefix, handler := range s.handlerMapping {
+		if strings.HasPrefix(r.URL.Path, prefix) {
+			handler.ServeHTTP(w, r)
+			return
+		}
+	}
+	s.defaultHandler.ServeHTTP(w, r)
 }
 
 type fakeHandler struct{}

--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -1,7 +1,23 @@
+/*
+Copyright 2024 API Testing Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package server_test
 
 import (
 	"net"
+	"net/http"
 	"testing"
 
 	"github.com/linuxsuren/api-testing/pkg/server"
@@ -18,4 +34,29 @@ func TestHTTPServer(t *testing.T) {
 
 	defaultHTTPServer := server.NewDefaultHTTPServer()
 	defaultHTTPServer.WithHandler(nil)
+}
+
+func TestCombineHandler(t *testing.T) {
+	defaultHandler := http.NewServeMux()
+	fakeHandler := http.NewServeMux()
+
+	t.Run("correct default handler", func(t *testing.T) {
+		combineHandler := server.NewDefaultCombineHandler()
+
+		combineHandler.PutHandler("", defaultHandler)
+		combineHandler.PutHandler("/fake", fakeHandler)
+
+		assert.NotEqual(t, defaultHandler, combineHandler.GetHandler())
+
+		fakeServer := server.NewFakeHTTPServer()
+		assert.Nil(t, fakeServer.Shutdown(nil))
+	})
+
+	t.Run("only one default handler", func(t *testing.T) {
+		combineHandler := server.NewDefaultCombineHandler()
+
+		combineHandler.PutHandler("", defaultHandler)
+
+		assert.Equal(t, defaultHandler, combineHandler.GetHandler())
+	})
 }


### PR DESCRIPTION
Usage: `atest server --mock-config api.yaml`