### PR TITLE
fix: cannot import sub-collection of postman

### DIFF
--- a/pkg/generator/importer_test.go
+++ b/pkg/generator/importer_test.go
@@ -64,6 +64,16 @@ func TestPostmanImport(t *testing.T) {
 		assert.Equal(t, expectedSuiteFromPostman, strings.TrimSpace(result), result)
 	})
 
+	t.Run("sub postman, from file", func(t *testing.T) {
+		suite, err := importer.ConvertFromFile("testdata/postman-sub.json")
+		assert.NoError(t, err)
+
+		var result string
+		result, err = converter.Convert(suite)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedSuiteFromSubPostman, strings.TrimSpace(result), result)
+	})
+
 	t.Run("simple postman, from URl", func(t *testing.T) {
 		defer gock.Off()
 		gock.New(urlFoo).Get("/").Reply(http.StatusOK).BodyString(simplePostman)
@@ -96,3 +106,6 @@ var simplePostman string
 
 //go:embed testdata/expected_suite_from_postman.yaml
 var expectedSuiteFromPostman string
+
+//go:embed testdata/expected_suite_from_sub_postman.yaml
+var expectedSuiteFromSubPostman string

--- a/pkg/generator/testdata/expected_suite_from_sub_postman.yaml
+++ b/pkg/generator/testdata/expected_suite_from_sub_postman.yaml
@@ -1,0 +1,9 @@
+name: Sub
+items:
+    - name: Get Sub Get New Request
+      request:
+        api: http://localhost?key=value
+        method: GET
+        header:
+            key: value
+        body: '{}'

--- a/pkg/generator/testdata/postman-sub.json
+++ b/pkg/generator/testdata/postman-sub.json
@@ -1,0 +1,41 @@
+{
+	"info": {
+		"_postman_id": "84b8940a-009e-4127-b84e-f4d6fd6b9972",
+		"name": "Sub",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "19536120"
+	},
+	"item": [
+		{
+			"name": "Get",
+			"item": [
+				{
+					"name": "Sub Get",
+					"item": [
+						{
+							"name": "New Request",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "key",
+										"value": "value",
+										"description": "description",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "http://localhost?key=value"
+								}
+							}
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Fixes #101 

**What this PR does / why we need it**:
1.The original logic cannot convert sub folders beyond one Postman folder.
2.I can only convert the body in JSON format is raw.Therefore,I have modified the structure of the PostmanBody according to the document https://learning.postman.com/collection-format/advanced-concepts/request-definition/. Now, I need to convert it to test suite. Do I need to modify the code structure of test suite Request?

```Go
type RequestBody struct {
	Value  string `json:"value" yaml:"value"`
	isJson bool
}
```