### PR TITLE
fix: error when opening atest-desktop on Windows

### DIFF
--- a/console/atest-desktop/main.js
+++ b/console/atest-desktop/main.js
@@ -15,7 +15,9 @@ log.initialize();
 log.transports.file.level = 'info';
 log.transports.file.resolvePathFn = () => path.join(atestHome, 'log.log');
 
-app.dock.setIcon(path.join(__dirname, "api-testing.png"))
+if (process.platform === 'darwin'){
+		app.dock.setIcon(path.join(__dirname, "api-testing.png"))
+}
 const createWindow = () => {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
@@ -108,12 +110,25 @@ app.whenReady().then(() => {
     log.info('start to write file with length %d', data.length)
     
     try { 
-      fs.writeFileSync(atestFromHome, data);
-    } 
+	if (process.platform === "win32") {
+		const file = fs.openSync(atestFromHome, 'w');
+		fs.writeSync(file, data, 0, data.length, 0);
+		fs.closeSync(file);
+	}else{
+		fs.writeFileSync(atestFromHome, data);
+	}
+	} 
     catch (e) { 
       log.error('Error Code: %s', e.code); 
+	  log.error('Error writing atest.exe to %s: %s', atestFromHome, e.message);
     }
-  }
+	if (fs.existsSync(atestFromHome)) {
+		log.info('atest.exe file exists at ${atestFromHome}')
+	} else {
+		log.error('Failed to write atest.exe to ${atestFromHome}')
+	}
+	}
+  
   fs.chmodSync(atestFromHome, 0o755); 
 
   serverProcess = spawn(atestFromHome, [

--- a/console/atest-desktop/main.js
+++ b/console/atest-desktop/main.js
@@ -120,13 +120,7 @@ app.whenReady().then(() => {
 	} 
     catch (e) { 
       log.error('Error Code: %s', e.code); 
-	  log.error('Error writing atest.exe to %s: %s', atestFromHome, e.message);
     }
-	if (fs.existsSync(atestFromHome)) {
-		log.info('atest.exe file exists at ${atestFromHome}')
-	} else {
-		log.error('Failed to write atest.exe to ${atestFromHome}')
-	}
 	}
   
   fs.chmodSync(atestFromHome, 0o755); 


### PR DESCRIPTION
**What type of PR is this?**
<!--
* "fix: fix atest-desktop bug"
-->
**Which issue(s) this PR fixes**:
<!--
1.Insert a conditional statement `if (process.platform === 'darwin')` at line 18. 
2.Add logic for Windows platform and file writing at line 112:
```
if (process.platform === "win32") {
		const file = fs.openSync(atestFromHome, 'w');
		fs.writeSync(file, data, 0, data.length, 0);
		fs.closeSync(file);
	}else{
		fs.writeFileSync(atestFromHome, data);
	}
```
-->
Fixes #
