### PR TITLE
feat: add serviceMonitor in the helm chart

### DIFF
--- a/helm/api-testing/templates/servicemonitor.yaml
+++ b/helm/api-testing/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "api-testing.fullname" . }}-servicemonitor
+  labels:
+    {{- include "api-testing.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "api-testing.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.serviceMonitor.interval }}
+      path: /metrics
+{{- end }}

--- a/helm/api-testing/values.yaml
+++ b/helm/api-testing/values.yaml
@@ -109,3 +109,7 @@ affinity: {}
 
 mongodb:
   enabled: false
+
+serviceMonitor:
+  enabled: false
+  interval: 15s


### PR DESCRIPTION
Fixes #358 

Create a serviceMonitor in the helm chart to expose the Promethus metrics. 
![image](https://github.com/LinuxSuRen/api-testing/assets/98792230/844b06de-351a-4894-b89c-94034a536b05)
