### PR TITLE
feat: add back to origin test case

### DIFF
--- a/console/atest-ui/src/App.vue
+++ b/console/atest-ui/src/App.vue
@@ -83,12 +83,24 @@ const handleChangeLan = (command: string) => {
   }
 };
 
-const ID = ref(null);
+const ID = ref(null)
 const toHistoryPanel = ({ ID: selectID, panelName: historyPanelName }) => {
   ID.value = selectID;
-  panelName.value = historyPanelName;
+  panelName.value = historyPanelName
 }
 
+const suiteName = ref(null)
+const caseName = ref(null)
+const toOriginTestcase = ({ originSuite, originCase, panelName: testingPanelName }) => {
+    suiteName.value = originSuite
+    caseName.value = originCase
+    panelName.value = testingPanelName
+}
+
+const clearOriginTestcase = () =>{
+    suiteName.value = null
+    caseName.value = null
+}
 </script>
 
 <template>
@@ -146,8 +158,8 @@ const toHistoryPanel = ({ ID: selectID, panelName: historyPanelName }) => {
           </el-dropdown>
         </el-col>
       </div>
-      <TestingPanel v-if="panelName === 'testing'" @toHistoryPanel="toHistoryPanel"/>
-      <TestingHistoryPanel v-else-if="panelName === 'history'" :ID="ID"/>
+      <TestingPanel v-if="panelName === 'testing'" @toHistoryPanel="toHistoryPanel" @clearOriginTestcase="clearOriginTestcase" :originSuite="suiteName" :originCase="caseName"/>
+      <TestingHistoryPanel v-else-if="panelName === 'history'" @toOriginTestcase="toOriginTestcase" :ID="ID"/>
       <MockManager v-else-if="panelName === 'mock'" />
       <StoreManager v-else-if="panelName === 'store'" />
       <SecretManager v-else-if="panelName === 'secret'" />

--- a/console/atest-ui/src/locales/en.json
+++ b/console/atest-ui/src/locales/en.json
@@ -26,6 +26,7 @@
         "viewHistory": "View History Test Case Result",
         "revert": "Revert",
         "goToHistory": "Go to History",
+        "goToOriginTestcase": "Go to Origin TestCase",
         "deleteAllHistory": "Delete All History"
     },
     "title": {

--- a/console/atest-ui/src/locales/zh.json
+++ b/console/atest-ui/src/locales/zh.json
@@ -26,6 +26,7 @@
         "viewHistory": "查看历史记录",
         "revert": "回退",
         "goToHistory": "跳转历史记录",
+        "goToOriginTestcase": "跳转原始测试用例",
         "deleteAllHistory": "删除所有历史记录"
     },
     "title": {

--- a/console/atest-ui/src/views/TestCase.vue
+++ b/console/atest-ui/src/views/TestCase.vue
@@ -37,7 +37,7 @@ const props = defineProps({
   historySuiteName: String,
   historyCaseID: String
 })
-const emit = defineEmits(['updated','toHistoryPanel'])
+const emit = defineEmits(['updated','toHistoryPanel', 'toOriginTestcase'])
 
 let querySuggestedAPIs = NewSuggestedAPIsQuery(Cache.GetCurrentStore().name!, props.suite!)
 const testResultActiveTab = ref(Cache.GetPreference().responseActiveTab)
@@ -606,6 +606,8 @@ const goToHistory = async (formEl) => {
   })
 }
 
+function goToOriginTestcase(){ emit('toOriginTestcase', { originSuite: props.suite, originCase: props.name, panelName: 'testing' })}
+
 const deleteAllHistory = async (formEl) => {
   if (!formEl) return
   caseRevertLoading.value = true
@@ -830,6 +832,7 @@ Magic.Keys(() => {
           v-if="!Cache.GetCurrentStore().readOnly && !isHistoryTestCase"
           >{{ t('button.save') }}</el-button>
         <el-button type="danger" @click="deleteCase" :icon="Delete">{{ t('button.delete') }}</el-button>
+        <el-button type="primary" @click="goToOriginTestcase" v-if="isHistoryTestCase">{{ t('button.goToOriginTestcase') }}</el-button>
         <el-button type="primary" @click="openDuplicateTestCaseDialog" :icon="CopyDocument" v-if="!isHistoryTestCase">{{ t('button.duplicate') }}</el-button>
         <el-button type="primary" @click="openCodeDialog">{{ t('button.generateCode') }}</el-button>
         <el-button type="primary" v-if="!isHistoryTestCase && Cache.GetCurrentStore().kind.name == 'atest-store-orm'" @click="openHistoryDialog">{{ t('button.viewHistory') }}</el-button>

--- a/console/atest-ui/src/views/TestingHistoryPanel.vue
+++ b/console/atest-ui/src/views/TestingHistoryPanel.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import TestCase from './TestCase.vue'
 import TestSuite from './TestSuite.vue'
-import TemplateFunctions from './TemplateFunctions.vue'
 import { reactive, ref, watch } from 'vue'
 import { ElTree, ElMessage } from 'element-plus'
 import type { FormInstance, FormRules } from 'element-plus'
@@ -255,6 +254,11 @@ const deviceAuthNext = () => {
   }
 }
 
+const emit = defineEmits(['toOriginTestcase']);
+const handleToOriginTestcase = (payload) => {
+    emit('toOriginTestcase', payload);
+};
+
 </script>
 
 <template>
@@ -278,11 +282,10 @@ const deviceAuthNext = () => {
               @node-click="handleNodeClick"
               data-intro="This is the test history tree. You can click the history test to browse it."
             />
-            <TemplateFunctions />
           </el-aside>
 
           <el-main style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px;">
-            <TestCase v-if="viewName === 'testcase'" :suite="testSuite" :kindName="testKind" :name="testCaseName"
+            <TestCase v-if="viewName === 'testcase'" @toOriginTestcase="handleToOriginTestcase" :suite="testSuite" :kindName="testKind" :name="testCaseName"
               :historySuiteName="historySuiteName" :historyCaseID="historyCaseID" @updated="loadStores" style="height: 100%;"
               data-intro="This is the test case editor. You can edit the test case here." />
           </el-main>


### PR DESCRIPTION
feat: add back to relate origin test case in history record page.
click this button can back to relate origin test case.
![image](https://github.com/user-attachments/assets/c52eff5d-e201-4a75-a8d1-fafc68d7829d)
If the original test case  is deleted, there will be the following prompt:
![image](https://github.com/user-attachments/assets/e44daa6c-b621-4d05-84d3-a6a772455d90)

