### PR TITLE
Fix: Handle text/plain response content type correctly

### DIFF
--- a/console/atest-ui/src/views/net.ts
+++ b/console/atest-ui/src/views/net.ts
@@ -25,7 +25,11 @@ async function DefaultResponseProcess(response: any) {
         const message = await response.json().then((data: any) => data.message)
         throw new Error(message)
     } else {
-        return response.json()
+        const contentType = response.headers.get('Content-Type') || '';
+        if (contentType.includes('text/plain')) {
+            return response.text();
+        }
+        return response.json();
     }
 }
 


### PR DESCRIPTION
#676 

## Fix text/plain response handling

### Issue
When sending a request with Content-Type text/plain;charset=UTF-8, the tool incorrectly attempts to parse the response as JSON, resulting in parsing errors for non-JSON content like "测试".

### Fix
Modified `DefaultResponseProcess` function to check the Content-Type header and handle text/plain responses appropriately:
- For text/plain responses, use `response.text()` instead of `response.json()`
- For other content types, continue using `response.json()`

### Testing
Verified that GET requests to http://localhost:8080/api/hello/message?key=testMessage with text/plain responses now display correctly without JSON parsing errors.