### PR TITLE
Fix: (#700) Improve error reporting for Query in fileLoader and nonLoader.

### DIFF
--- a/pkg/testing/loader_file.go
+++ b/pkg/testing/loader_file.go
@@ -18,6 +18,7 @@ package testing
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -516,8 +517,11 @@ func (l *fileLoader) Close() {
 }
 
 func (l *fileLoader) Query(query map[string]string) (result DataResult, err error) {
-	result.Pairs = map[string]string{
-		"message": "not support",
-	}
+	err = errors.New("Query functionality is not yet implemented for fileLoader")
+	return
+}
+
+func (l *fileLoader) GetRoundTripper(name string) (roundTripper http.RoundTripper, err error) {
+	err = fmt.Errorf("not support")
 	return
 }

--- a/pkg/testing/loader_non.go
+++ b/pkg/testing/loader_non.go
@@ -15,6 +15,10 @@ limitations under the License.
 */
 package testing
 
+import (
+	"errors"
+)
+
 // nonLoader is an empty implement for avoid too many nil check
 type nonLoader struct{}
 
@@ -151,5 +155,6 @@ func (l *nonLoader) Close() {
 }
 
 func (l *nonLoader) Query(query map[string]string) (result DataResult, err error) {
+	err = errors.New("Query functionality is not implemented for nonLoader")
 	return
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes:**
Fixes #700 

**What type of PR is this?**
Fix: Improve error reporting for unimplemented Query in loaders

**What this PR does / why we need it:**
This PR refactors the Query methods in pkg/testing/loader_file.go and pkg/testing/loader_non.go.
Previously, these methods did not clearly indicate their inability to perform database queries in a way that aligns with Go's error handling conventions:
fileLoader.Query returned a nil error while passing a "not support" message through the data payload.
nonLoader.Query returned a nil error and an empty result, failing silently.
These behaviors made it harder for calling code to reliably determine if a query was unsupported and could lead to confusion during debugging.
This change modifies both methods to return an explicit, non-nil error (e.g., errors.New("Query functionality is not yet implemented for fileLoader")). This provides:

1. Clearer Error Indication: Callers can use the standard if err != nil check.
2. Adherence to Go Conventions: Aligns with idiomatic Go error handling.
3. Improved Debuggability: Explicit errors make it easier to understand limitations.
4. This PR does not implement query functionality for these loaders but improves the clarity of their current unimplemented state.
