### PR TITLE
integrate atest-ext-ai plugin into auto-build process

### DIFF
--- a/cmd/testdata/stores.yaml
+++ b/cmd/testdata/stores.yaml
@@ -6,7 +6,30 @@ stores:
       url: xxx
       readonly: false
       disabled: false
+    - name: ai
+      kind:
+        name: atest-ext-ai
+        enabled: true
+      url: ""
+      readonly: false
+      disabled: false
+      properties:
+        - key: "provider"
+          description: "AI provider (local, openai, claude)"
+          defaultValue: "local"
+        - key: "model"
+          description: "AI model name"
+          defaultValue: "codellama"
+        - key: "endpoint"
+          description: "AI service endpoint"
+          defaultValue: "http://localhost:11434"
 plugins:
     - name: atest-store-git
       url: unix:///tmp/atest-store-git.sock
       enabled: true
+    - name: atest-ext-ai
+      url: unix:///tmp/atest-ext-ai.sock
+      enabled: true
+      description: "AI Extension Plugin for intelligent SQL generation and execution"
+      version: "latest"
+      registry: "ghcr.io/linuxsuren/atest-ext-ai"

--- a/console/atest-desktop/forge.config.js
+++ b/console/atest-desktop/forge.config.js
@@ -71,6 +71,15 @@ module.exports = {
 
     </Product>`
           );
+
+          // Ensure INSTALLDIR is properly defined in the directory structure
+          msiCreator.wixTemplate = msiCreator.wixTemplate.replace(
+            '<Directory Id="TARGETDIR" Name="SourceDir">',
+            `<Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLDIR" Name="API Testing" />
+      </Directory>`
+          );
         }
       }
     }

--- a/console/atest-desktop/forge.config.js
+++ b/console/atest-desktop/forge.config.js
@@ -72,13 +72,11 @@ module.exports = {
     </Product>`
           );
 
-          // Ensure INSTALLDIR is properly defined in the directory structure
+          // Ensure INSTALLDIR is properly defined in the existing ProgramFilesFolder
           msiCreator.wixTemplate = msiCreator.wixTemplate.replace(
-            '<Directory Id="TARGETDIR" Name="SourceDir">',
-            `<Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLDIR" Name="API Testing" />
-      </Directory>`
+            '<Directory Id="ProgramFilesFolder">',
+            `<Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLDIR" Name="API Testing" />`
           );
         }
       }

--- a/console/atest-ui/src/views/store.ts
+++ b/console/atest-ui/src/views/store.ts
@@ -38,6 +38,7 @@ const ExtensionKindRedis = "atest-store-redis"
 const ExtensionKindMongoDB = "atest-store-mongodb"
 const ExtensionKindElasticsearch = "atest-store-elasticsearch"
 const ExtensionKindOpengeMini = "atest-store-opengemini"
+const ExtensionKindAI = "atest-ext-ai"
 
 export const ExtensionKind = {
     ExtensionKindGit,
@@ -49,7 +50,8 @@ export const ExtensionKind = {
     ExtensionKindRedis,
     ExtensionKindMongoDB,
     ExtensionKindElasticsearch,
-    ExtensionKindOpengeMini
+    ExtensionKindOpengeMini,
+    ExtensionKindAI
 }
 
 const MySQL = "mysql";

--- a/sample/ai-extension.yaml
+++ b/sample/ai-extension.yaml
@@ -1,0 +1,26 @@
+stores:
+  - name: ai
+    kind:
+      name: atest-ext-ai
+      enabled: true
+    url: ""
+    readonly: false
+    disabled: false
+    properties:
+      - key: "provider"
+        description: "AI provider (local, openai, claude)"
+        defaultValue: "local"
+      - key: "model"
+        description: "AI model name"
+        defaultValue: "codellama"
+      - key: "endpoint"
+        description: "AI service endpoint"
+        defaultValue: "http://localhost:11434"
+
+plugins:
+  - name: atest-ext-ai
+    url: unix:///tmp/atest-ext-ai.sock
+    enabled: true
+    description: "AI Extension Plugin for intelligent SQL generation and execution"
+    version: "latest"
+    registry: "ghcr.io/linuxsuren/atest-ext-ai"


### PR DESCRIPTION
- Add AI extension configuration in sample/ai-extension.yaml
- Update testdata/stores.yaml to include AI plugin registration
- Register atest-ext-ai in UI store types (console/atest-ui/src/views/store.ts)
- Enable automatic download and startup via extension registry

This enables 'make run-server' to automatically build and connect AI plugin
without manual download of atest-ext-ai repository.
