### PR TITLE
fix: fully localize Chinese interface for test cases

### DIFF
--- a/console/atest-ui/src/locales/en.json
+++ b/console/atest-ui/src/locales/en.json
@@ -9,6 +9,10 @@
         "save": "Save",
         "delete": "Delete",
         "send": "Send",
+        "beautify": "Beautify",
+        "minify": "Minify",
+        "download": "Download",
+        "batchSend": "Batch Send",
         "copy": "Copy",
         "ok": "OK",
         "next-page": "Next",
@@ -59,14 +63,18 @@
         "data": "Data",
         "setting": "Setting",
         "keyBindings": "Key Bindings",
-        "theme":"Theme"
+        "theme":"Theme",
+        "newTestCaseName": "New Test Case Name"
     },
     "tip": {
         "filter": "Filter Keyword",
         "noParameter": "No Parameter",
         "testsuite": "Test Suite:",
         "apiAddress": "API Address:",
-        "runningAt": "Running At:"
+        "runningAt": "Running At:",
+        "chooseBodyFormat": "Choose the body format",
+        "responseBodyTooLarge": "Response body is too large, please download to view.",
+        "bodySize": "Body Size"
     },
     "field": {
         "name": "Name",
@@ -86,7 +94,19 @@
         "proxy": "Proxy",
         "shortcut": "Shortcut",
         "description": "Description",
-        "insecure": "Insecure"
+        "insecure": "Insecure",
+        "query": "Query",
+        "header": "Header",
+        "cookie": "Cookie",
+        "body": "Body",
+        "expected": "Expected",
+        "statusCode": "Status Code",
+        "expectedHeaders": "Expected Headers",
+        "bodyFieldExpect": "Body Field Expect",
+        "verify": "Verify",
+        "schema": "Schema",
+        "method": "Method",
+        "filename": "Filename"
     },
     "proxy": {
         "http": "HTTP Proxy",

--- a/console/atest-ui/src/locales/zh.json
+++ b/console/atest-ui/src/locales/zh.json
@@ -9,6 +9,10 @@
         "save": "保存",
         "delete": "删除",
         "send": "发送",
+        "beautify": "格式化",
+        "minify": "压缩",
+        "download": "下载",
+        "batchSend": "批量发送",
         "copy": "拷贝",
         "ok": "确定",
         "next-page": "下一页",
@@ -55,14 +59,18 @@
         "data": "数据",
         "setting": "设置",
         "keyBindings": "按键绑定",
-        "theme": "主题"
+        "theme": "主题",
+        "newTestCaseName": "新测试用例名称"
     },
     "tip": {
         "filter": "过滤",
         "noParameter": "无参数",
         "testsuite": "测试集：",
         "apiAddress": "API 地址：",
-        "runningAt": "运行于："
+        "runningAt": "运行于：",
+        "chooseBodyFormat": "选择请求体格式",
+        "responseBodyTooLarge": "响应体过大，请下载后查看。",
+        "bodySize": "请求体大小"
     },
     "field": {
         "name": "名称",
@@ -82,7 +90,19 @@
         "proxy": "代理",
         "shortcut": "快捷键",
         "description": "描述",
-        "insecure": "忽略证书验证"
+        "insecure": "忽略证书验证",
+        "query": "查询参数",
+        "header": "请求头",
+        "cookie": "Cookie",
+        "body": "请求体",
+        "expected": "预期结果",
+        "statusCode": "状态码",
+        "expectedHeaders": "预期响应头",
+        "bodyFieldExpect": "请求体字段预期",
+        "verify": "验证",
+        "schema": "Schema",
+        "method": "方法",
+        "filename": "文件名"
     },
     "proxy": {
         "http": "HTTP 代理",

--- a/console/atest-ui/src/views/TestCase.vue
+++ b/console/atest-ui/src/views/TestCase.vue
@@ -969,7 +969,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
               v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'"
               v-model="testCaseWithSuite.data.request.method"
               class="m-2"
-              placeholder="Method"
+              :placeholder="t('field.method')"
               size="default"
               test-id="case-editor-method"
               :disabled="isHistoryTestCase"
@@ -1008,7 +1008,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
               <template #dropdown>
                 <el-dropdown-menu>
                   <el-dropdown-item @click="openParameterDialog">{{ t('button.sendWithParam') }}</el-dropdown-item>
-                  <el-dropdown-item @click="openBatchRunDialog">Batch Send</el-dropdown-item>
+                  <el-dropdown-item @click="openBatchRunDialog">{{ t('button.batchSend') }}</el-dropdown-item>
                 </el-dropdown-menu>
               </template>
             </el-dropdown>
@@ -1022,7 +1022,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
         <el-tab-pane name="query" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
           <template #label>
             <el-badge :value="testCaseWithSuite.data.request.query.length - 1"
-              :hidden="testCaseWithSuite.data.request.query.length <=1 " class="item">Query</el-badge>
+              :hidden="testCaseWithSuite.data.request.query.length <=1 " class="item">{{ t('field.query') }}</el-badge>
           </template>
           <el-table :data="testCaseWithSuite.data.request.query" style="width: 100%">
             <el-table-column label="Key" width="180">
@@ -1048,7 +1048,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
         <el-tab-pane name="header">
           <template #label>
             <el-badge :value="testCaseWithSuite.data.request.header.length - 1"
-              :hidden="testCaseWithSuite.data.request.header.length <= 1" class="item">Header</el-badge>
+              :hidden="testCaseWithSuite.data.request.header.length <= 1" class="item">{{ t('field.header') }}</el-badge>
           </template>
           <el-table :data="testCaseWithSuite.data.request.header" style="width: 100%">
             <el-table-column label="Key" width="180">
@@ -1081,7 +1081,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
         <el-tab-pane name="cookie">
           <template #label>
             <el-badge :value="testCaseWithSuite.data.request.cookie.length - 1"
-              :hidden="testCaseWithSuite.data.request.cookie.length <= 1" class="item">Cookie</el-badge>
+              :hidden="testCaseWithSuite.data.request.cookie.length <= 1" class="item">{{ t('field.cookie') }}</el-badge>
           </template>
           <el-table :data="testCaseWithSuite.data.request.cookie" style="width: 100%">
             <el-table-column label="Key">
@@ -1104,12 +1104,12 @@ Magic.LoadMagicKeys('TestCase', new Map([
 
         <el-tab-pane name="body">
           <span style="margin-right: 10px; padding-right: 5px;">
-            <Button type="primary" @click="jsonFormat(4)">Beautify</Button>
-            <Button type="primary" @click="jsonFormat(0)">Minify</Button>
-            <el-text class="mx-1">Choose the body format</el-text>
+            <Button type="primary" @click="jsonFormat(4)">{{ t('button.beautify') }}</Button>
+            <Button type="primary" @click="jsonFormat(0)">{{ t('button.minify') }}</Button>
+            <el-text class="mx-1" style="margin-left: 16px;">{{ t('tip.chooseBodyFormat') }}</el-text>
           </span>
           <template #label>
-            <el-badge :is-dot="testCaseWithSuite.data.request.body !== ''" class="item">Body</el-badge>
+            <el-badge :is-dot="testCaseWithSuite.data.request.body !== ''" class="item">{{ t('field.body') }}</el-badge>
           </template>
           <el-radio-group v-model="bodyType" @change="bodyTypeChange">
             <el-radio :value="1">none</el-radio>
@@ -1123,7 +1123,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
           <div style="flex-grow: 1;">
             <div v-if="bodyType === 6">
               <el-row>
-                <el-col :span="4">Filename:</el-col>
+                <el-col :span="4">{{ t('field.filename') }}:</el-col>
                 <el-col :span="20">
                   <el-input v-model="testCaseWithSuite.data.request.filepath" placeholder="file=sample.txt" @change="filepathChange" />
                 </el-col>
@@ -1155,10 +1155,10 @@ Magic.LoadMagicKeys('TestCase', new Map([
           </div>
         </el-tab-pane>
 
-        <el-tab-pane label="Expected" name="expected" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
+        <el-tab-pane :label="t('field.expected')" name="expected" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
           <el-row>
             <el-col :span="4">
-              Status Code:
+              {{ t('field.statusCode') }}:
             </el-col>
             <el-col :span="20">
               <el-input
@@ -1186,7 +1186,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
           </el-row>
         </el-tab-pane>
 
-        <el-tab-pane label="Expected Headers" name="expected-headers" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
+        <el-tab-pane :label="t('field.expectedHeaders')" name="expected-headers" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
           <el-table :data="testCaseWithSuite.data.response.header" style="width: 100%">
             <el-table-column label="Key" width="180">
               <template #default="scope">
@@ -1208,7 +1208,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
           </el-table>
         </el-tab-pane>
 
-        <el-tab-pane label="BodyFiledExpect" name="bodyFieldExpect" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
+        <el-tab-pane :label="t('field.bodyFieldExpect')" name="bodyFieldExpect" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
           <el-table :data="testCaseWithSuite.data.response.bodyFieldsExpect" style="width: 100%">
             <el-table-column label="Key" width="180">
               <template #default="scope">
@@ -1232,13 +1232,13 @@ Magic.LoadMagicKeys('TestCase', new Map([
           </el-table>
         </el-tab-pane>
 
-        <el-tab-pane label="Verify" name="verify" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
+        <el-tab-pane :label="t('field.verify')" name="verify" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
           <div v-for="verify in testCaseWithSuite.data.response.verify" :key="verify">
             <el-input :value="verify" :readonly="isHistoryTestCase"/>
           </div>
         </el-tab-pane>
 
-        <el-tab-pane label="Schema" name="schema" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
+        <el-tab-pane :label="t('field.schema')" name="schema" v-if="props.kindName !== 'tRPC' && props.kindName !== 'gRPC'">
           <el-input
             v-model="testCaseWithSuite.data.response.schema"
             :autosize="{ minRows: 4, maxRows: 20 }"
@@ -1384,11 +1384,11 @@ Magic.LoadMagicKeys('TestCase', new Map([
 
           <Codemirror v-model="testResult.output"/>
         </el-tab-pane>
-        <el-tab-pane label="Body" name="body">
+        <el-tab-pane :label="t('field.body')" name="body">
           <div v-if="testResult.bodyObject">
             <el-input :prefix-icon="Search" @change="responseBodyFilter" v-model="responseBodyFilterText"
               clearable placeholder="$.data[?(@.status==='SUCCEED')]">
-              <template #prepend v-if="testResult.bodyLength > 0">Body Size: {{testResult.bodyLength}}</template>
+              <template #prepend v-if="testResult.bodyLength > 0">{{ t('tip.bodySize') }}: {{testResult.bodyLength}}</template>
               <template #suffix>
                 <a href="https://www.npmjs.com/package/jsonpath-plus" target="_blank"><el-icon><Help /></el-icon></a>
               </template>
@@ -1401,10 +1401,10 @@ Magic.LoadMagicKeys('TestCase', new Map([
             <div v-else-if="isResponseFile" style="padding-top: 10px;">
             <el-row>
               <el-col :span="10">
-                <div>Response body is too large, please download to view.</div>
+                <div>{{ t('tip.responseBodyTooLarge') }}</div>
               </el-col>
               <el-col :span="2">
-                <Button type="primary" @click="downloadResponseFile">Download</Button>
+                <Button type="primary" @click="downloadResponseFile">{{ t('button.download') }}</Button>
               </el-col>
             </el-row>
           </div>
@@ -1413,7 +1413,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
         <el-tab-pane name="response-header">
           <template #label>
             <el-badge :value="testResult.header.length" 
-              :hidden="testResult.header.length === 0" class="item">Header</el-badge>
+              :hidden="testResult.header.length === 0" class="item">{{ t('field.header') }}</el-badge>
           </template>
           <el-table :data="testResult.header" style="width: 100%">
             <el-table-column label="Key" width="200">
@@ -1436,7 +1436,7 @@ Magic.LoadMagicKeys('TestCase', new Map([
 
     <el-drawer v-model="duplicateTestCaseDialog">
         <template #default>
-            New Test Case Name:<el-input v-model="targetTestCaseName" />
+            {{ t('title.newTestCaseName') }}:<el-input v-model="targetTestCaseName" />
         </template>
         <template #footer>
             <Button type="primary" @click="duplicateTestCase">{{ t('button.ok') }}</Button>


### PR DESCRIPTION
## Description

I had completely localizes the `TestCase.vue` components to ensure that there is accurate rendering of component in both Chinese & English language and also manage the minor spacing around `Chose the Body Format` button


## Related Issues 
Fixes #701 


## Outcome
<img width="1916" height="906" alt="image" src="https://github.com/user-attachments/assets/8a9398fb-1d12-4a3a-836c-ad5d3a3b60a2" />


## Verification

- Validated that switching languages correctly translates the tabs, buttons, and placeholders dynamically.
- Ensured formatting spacing handles different language lengths effectively. 

## Notes 
- Some component were remained in `Eng` language because I had followed the standard procedure by replicating from software like `Postman` (as they also let some component untouched no matter the language)
